### PR TITLE
Addition of Weekly Tracker and changes

### DIFF
--- a/FEAST/app/src/main/java/com/example/feast/CrowdLevel.java
+++ b/FEAST/app/src/main/java/com/example/feast/CrowdLevel.java
@@ -1,32 +1,35 @@
 package com.example.feast;
 
+import android.os.Build;
+
+import androidx.annotation.RequiresApi;
+
+import com.google.firebase.database.DataSnapshot;
 import com.google.firebase.database.DatabaseReference;
 
+import java.time.*;
 import java.util.HashMap;
 
 public class CrowdLevel extends FNBEstablishment{
 
     static final String[] crowdLevelsString = {"Not Crowded", "A Little Crowded", "Somewhat Crowded", "Very Crowded", "Full"};
-    static final Double[] crowdLevelsDouble = {0.2, 0.5, 0.8, 1.0};
+    static final Double[] crowdLevelsThresholdDouble = {0.2, 0.5, 0.8, 1.0};
 
-    double currentCapacity;
-    double hourlyHighestCapacity;
+    int currentCapacity;
     double crowdPercentage;
     String currentCrowdLevel;
+    HashMap<Integer, Integer> hourlyHighestCapacity;
 
+    @RequiresApi(api = Build.VERSION_CODES.O)
     CrowdLevel()
     {
         this.currentCapacity = 1;
-        this.hourlyHighestCapacity = 1;
         this.crowdPercentage = 1;
         this.currentCrowdLevel = "Not Crowded";
-    }
-
-    CrowdLevel(int currentCapacity, int hourlyHighestCapacity, double crowdPercentage, String currentCrowdLevel)
-    {
-        this.currentCapacity = 1;
-        this.hourlyHighestCapacity = 1;
-        this.crowdPercentage = 1;
+        this.hourlyHighestCapacity = new HashMap<>();
+        {
+            hourlyHighestCapacity.put(LocalTime.now().getHour(), this.currentCapacity);
+        }
     }
 
     public double getCurrentCapacity()
@@ -34,7 +37,7 @@ public class CrowdLevel extends FNBEstablishment{
         return this.currentCapacity;
     }
 
-    public double getHourlyHighestCapacity()
+    public HashMap<Integer, Integer> getHourlyHighestCapacity()
     {
         return this.hourlyHighestCapacity;
     }
@@ -45,27 +48,36 @@ public class CrowdLevel extends FNBEstablishment{
         return this.crowdPercentage;
     }
 
-    public void refreshInfo(DatabaseReference db)
+    @RequiresApi(api = Build.VERSION_CODES.O)
+    public void refreshInfo(DataSnapshot ds)
     {
         //Get value of current capacity of store from database
+        this.currentCapacity = ds.child("people_count").child(super.name).child("currentCapacity").getValue(Integer.class);
         //Get value of hourly highest capacity of store from database
+        if (hourlyHighestCapacity.containsKey(LocalTime.now().getHour()))
+        {
+            if (hourlyHighestCapacity.get(LocalTime.now().getHour()) < this.currentCapacity)
+            {
+                hourlyHighestCapacity.put(LocalTime.now().getHour(), this.currentCapacity);
+            }
+        }
     }
 
     public String getCurrentCrowdLevel()
     {
-        if (this.calculateCrowdPercentage() <= crowdLevelsDouble[0])
+        if (this.calculateCrowdPercentage() <= crowdLevelsThresholdDouble[0])
         {
             return crowdLevelsString[0];
         }
-        else if (this.calculateCrowdPercentage() > crowdLevelsDouble[0] && this.calculateCrowdPercentage() <= crowdLevelsDouble[1])
+        else if (this.calculateCrowdPercentage() > crowdLevelsThresholdDouble[0] && this.calculateCrowdPercentage() <= crowdLevelsThresholdDouble[1])
         {
             return crowdLevelsString[1];
         }
-        else if (this.calculateCrowdPercentage() > crowdLevelsDouble[1] && this.calculateCrowdPercentage() <= crowdLevelsDouble[2])
+        else if (this.calculateCrowdPercentage() > crowdLevelsThresholdDouble[1] && this.calculateCrowdPercentage() <= crowdLevelsThresholdDouble[2])
         {
             return crowdLevelsString[2];
         }
-        else if (this.calculateCrowdPercentage() > crowdLevelsDouble[2] && this.calculateCrowdPercentage() <= crowdLevelsDouble[3])
+        else if (this.calculateCrowdPercentage() > crowdLevelsThresholdDouble[2] && this.calculateCrowdPercentage() <= crowdLevelsThresholdDouble[3])
         {
             return crowdLevelsString[3];
         }
@@ -74,6 +86,5 @@ public class CrowdLevel extends FNBEstablishment{
             return crowdLevelsString[4];
         }
     }
-
 
 }

--- a/FEAST/app/src/main/java/com/example/feast/DailyTracker.java
+++ b/FEAST/app/src/main/java/com/example/feast/DailyTracker.java
@@ -1,0 +1,35 @@
+package com.example.feast;
+
+import android.os.Build;
+
+import androidx.annotation.RequiresApi;
+
+import java.time.LocalTime;
+import java.util.HashMap;
+
+@RequiresApi(api = Build.VERSION_CODES.O)
+public class DailyTracker extends WeeklyTracker{
+
+    private HashMap<Integer, Integer> hourlyHistoricalData;
+
+    DailyTracker()
+    {
+        this.hourlyHistoricalData = new HashMap<>();
+        for (int i = Integer.parseInt(super.openHour); i <= Integer.parseInt(super.closeHour); i++)
+        {
+            hourlyHistoricalData.put(i, 0);
+        }
+
+    }
+
+    public void setHourlyHistoricalData(int currentHour, Integer updatedCapacity)
+    {
+        this.hourlyHistoricalData.put(currentHour, updatedCapacity);
+    }
+    
+    public int getHourlyHistoricalData(LocalTime time)
+    {
+        return this.hourlyHistoricalData.get(time);
+    }
+
+}

--- a/FEAST/app/src/main/java/com/example/feast/FNBEstablishment.java
+++ b/FEAST/app/src/main/java/com/example/feast/FNBEstablishment.java
@@ -7,8 +7,9 @@ import androidx.annotation.RequiresApi;
 import java.time.*;
 import java.util.HashMap;
 
-public class FNBEstablishment {
+public class FNBEstablishment implements Comparable<FNBEstablishment>{
     int maxCapacity;
+    boolean isFavorite;
     String name;
     String openHour;
     String closeHour;
@@ -23,6 +24,7 @@ public class FNBEstablishment {
     FNBEstablishment()
     {
         maxCapacity = 1;
+        isFavorite = false;
         name = "defaultFNB";
         openHour = "08";
         openMin = "00";
@@ -37,9 +39,10 @@ public class FNBEstablishment {
 
     }
 
-    FNBEstablishment(int maxCapacity, String name, String openingHour, String closingHour, String description) //openingHour and closingHour must be in "hh:mm" format
+    FNBEstablishment(int maxCapacity, boolean isFavorite, String name, String openingHour, String closingHour, String description) //openingHour and closingHour must be in "hh:mm" format
     {
         this.maxCapacity = maxCapacity;
+        this.isFavorite = isFavorite;
         this.name = name;
         this.description = description;
         for (DayOfWeek d: DayOfWeek.values()){      //From Sunday to Saturday
@@ -62,6 +65,14 @@ public class FNBEstablishment {
         this.closeMin = String.valueOf(closeMinCharArray);
         this.closeSec = String.valueOf(closeSecCharArray);
     }
+
+    public void setMaxCapacity(int maxCapacity) { this.maxCapacity = maxCapacity; }
+
+    public int getMaxCapacity() { return this.maxCapacity; }
+
+    public void setIsFavorite(boolean isFavorite) { this.isFavorite = isFavorite; }
+
+    public boolean getIsFavorite() { return this.isFavorite; }
 
     public void setOpeningClosingTime(String newOpeningHour, String newClosingHour)     //must be in "hh:mm" format
     {
@@ -152,4 +163,21 @@ public class FNBEstablishment {
 //Future Improvements: (If we not lazy)
 // does not account for specific dates closed
 // does not account for different closing times on different days
+
+    @Override
+    public int compareTo(FNBEstablishment otherFNBEstablishment)
+    {
+        if (this.isFavorite == otherFNBEstablishment.isFavorite)
+        {
+            return this.name.compareTo(otherFNBEstablishment.name);
+        }
+        else if (this.isFavorite)
+        {
+            return 1;
+        }
+        else
+        {
+            return -1;
+        }
+    }
 }

--- a/FEAST/app/src/main/java/com/example/feast/WeeklyTracker.java
+++ b/FEAST/app/src/main/java/com/example/feast/WeeklyTracker.java
@@ -1,0 +1,43 @@
+package com.example.feast;
+
+import android.os.Build;
+
+import androidx.annotation.RequiresApi;
+
+import java.time.*;
+import java.util.HashMap;
+
+@RequiresApi(api = Build.VERSION_CODES.O)
+public class WeeklyTracker extends CrowdLevel{
+
+    private final LocalDate dateCreated;
+
+    private HashMap<DayOfWeek, DailyTracker> weeklyHistoricalData;
+
+    WeeklyTracker()
+    {
+        dateCreated = LocalDate.now();
+
+        weeklyHistoricalData = new HashMap<>();
+
+        for (DayOfWeek d: DayOfWeek.values())
+        {
+            weeklyHistoricalData.put(d, new DailyTracker());
+        }
+    }
+
+    public LocalDate getDateCreated() { return dateCreated; }
+
+    public void setWeeklyHistoricalData(DayOfWeek currentDay, int currentHour)
+    {
+        DailyTracker dailyTrackerToUpdate = weeklyHistoricalData.get(currentDay);
+        dailyTrackerToUpdate.setHourlyHistoricalData(currentHour, hourlyHighestCapacity.get(currentHour));
+    }
+
+    public HashMap<DayOfWeek, DailyTracker> getWeeklyHistoricalData()
+    {
+        return weeklyHistoricalData;
+    }
+
+
+}

--- a/FEAST/app/src/test/java/com/example/feast/FNBEstablishmentUnitTest.java
+++ b/FEAST/app/src/test/java/com/example/feast/FNBEstablishmentUnitTest.java
@@ -11,7 +11,7 @@ import java.time.DayOfWeek;
  *
  * @see <a href="http://d.android.com/tools/testing">Testing documentation</a>
  */
-public class ExampleUnitTest {
+public class FNBEstablishmentUnitTest {
     @Test
     public void FNBEstablishmentDefaultCheck(){
         FNBEstablishment default_ = new FNBEstablishment();
@@ -19,9 +19,10 @@ public class ExampleUnitTest {
     }
     @Test
     public void CreateFNBEstablishmentCheck(){
-        FNBEstablishment creation = new FNBEstablishment(10, "creation", "00:00:00", "23:59:59", "24/7");
+        FNBEstablishment creation = new FNBEstablishment(10, false, "creation", "00:00:00", "23:59:59", "24/7");
         System.out.println(creation.openHour);
         assertEquals(10, creation.maxCapacity);
+        assertEquals(false, creation.isFavorite);
         assertEquals("creation", creation.name);
         assertEquals("00", creation.openHour);
         assertEquals("00", creation.openMin);

--- a/FEAST/app/src/test/java/com/example/feast/WeeklyTrackerTestUnit.java
+++ b/FEAST/app/src/test/java/com/example/feast/WeeklyTrackerTestUnit.java
@@ -1,0 +1,24 @@
+package com.example.feast;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+import java.time.DayOfWeek;
+
+public class WeeklyTrackerTestUnit {
+
+    @Test
+    public void WeeklyTrackerDefaultCheck()
+    {
+        WeeklyTracker defaultWeeklyTracker = new WeeklyTracker();
+        System.out.println(defaultWeeklyTracker.getDateCreated());
+    }
+
+    /*@Test
+    public void DailyTrackerCheck()
+    {
+        DailyTracker defaultDailyTracker = new DailyTracker();
+    }*/
+
+}


### PR DESCRIPTION
Change log:
- Added Weekly Tracker, extends Crowd Level, contains subclass DailyTracker (Despite the name it tracks the hourly highest capacity)
- FNBEstablishment now implements Comparable, compares based on whether FNB isFavourite (boolean) by user and name (String) of FNB
- CrowdLevel now implements method refreshInfo, updates currentCapacity by taking DataSnapshot from firebase and referencing a child with the name of FNB. Also checks and updates hourlyHighestCapacity if new currentCapacity is greater than previous hourlyHighestCapacity
- Changed ExampleUnitTest class to FNBEstablishmentUnitTest for Javier's test cases for FNB
- Added WeeklyTrackerTestUnit class

NOTES:
- There are issues with WeeklyTracker, briefly the test cases throws a StackOverflowError, I tried following the debug log but cannot really figure out what is wrong, need help
- CrowdLevel's refreshInfo method has not been tested yet and is not completely modular for now, changes needed once merged with Front End